### PR TITLE
run tests when building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
-*.pyc
+# User content belongs under recipe/.
+# Feedstock configuration goes in `conda-forge.yml`
+# Everything else is managed by the conda-smithy rerender process.
+# Please do not modify
 
-build_artifacts
+*
+!/conda-forge.yml
+
+!/*/
+!/recipe/**
+!/.ci_support/**
+
+*.pyc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,14 @@ requirements:
     - {{ native }}zlib           # [win]
 
 test:
+  requires:
+    - r-bit64
+    - r-r.utils
   commands:
-    - Rscript -e "require('data.table'); data.table::test.data.table()"
+    - $R -e "library('data.table')"                   # [not win]
+    - $R -e "data.table::test.data.table()"           # [not win]
+    - "\"%R%\" -e \"library('data.table')\""          # [win]
+    - "\"%R%\" -e \"data.table::test.data.table()\""  # [win]
 
 about:
   home: https://r-datatable.com

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: true  # [win]
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/
@@ -43,8 +43,7 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('data.table')"           # [not win]
-    - "\"%R%\" -e \"library('data.table')\""  # [win]
+    - Rscript -e "require('data.table'); data.table::test.data.table()"
 
 about:
   home: https://r-datatable.com


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

## Summary

This PR proposes running `{data.table}`'s unit tests as a part of builds here.

This ~introduces 0 new build-time dependencies and~ offers significantly higher coverage of potential build problems than the current testing strategy, which is "check that `library(data.table)` runs without error".

Let's see what the change in build time is when CI runs, but assuming it's on the order of 0-3 minutes, I think it's worth it in exchange for stronger guarantees about correctness of the build here. Especially for a project like `{data.table}`, which is depended on by hundreds of other R packages (see "reverse imports" at https://cran.r-project.org/web/packages/data.table/index.html).

## How I tested this

Locally on my mac (intel chip, macOS 12.2.1, 8GB RAM), ran the following on this branch:

```shell
docker run \
    --rm \
    -v $(pwd):/opt/data.table \
    -w /opt/data.table \
    --entrypoint="" \
    -it condaforge/linux-anvil-cos7-x86_64 \
    bash

conda build .
```

Saw that build succeed, and this output confirming that the tests ran successsfully:

```text
All 8997 tests (last 2163) in tests/tests.Rraw.bz2 completed ok in 25.8s elapsed (28.2s cpu)
+ exit 0

Resource usage statistics from testing r-data.table:
   Process count: 4
   CPU time: Sys=0:00:00.8, User=0:00:27.6
   Memory: 177.3M
   Disk usage: 16B
   Time elapsed: 0:00:28.1
```

For details on that `test.data.table()` function, see https://rdatatable.gitlab.io/data.table/reference/test.data.table.html?q=test.data#ref-examples.

Thanks very much for your time and consideration.